### PR TITLE
FIX: data is sent synchronously

### DIFF
--- a/cmd/servicedirectory.go
+++ b/cmd/servicedirectory.go
@@ -111,6 +111,6 @@ func processData() {
 
 	events := datastore.GetEvents(data)
 	if len(events) > 0 {
-		sendQueue.Enqueue(events)
+		go sendQueue.Enqueue(events)
 	}
 }


### PR DESCRIPTION
An issue that was preventing data from being enqueued
when other data was processing is now fixed.

By enqueing data in another goroutine, we can return immediately
and poll regularly.

This fixes #6 

Signed-off-by: Elis Lulja <elulja@cisco.com>