### PR TITLE
Fix duplicate example

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -144,8 +144,6 @@ components:
           metadata:
           - value: uhd-video
             key: profile
-          - value: uhd-video
-            key: profile
           address: 131.37.88.10
           port: 8080
           name: customers-endpoint
@@ -168,8 +166,6 @@ components:
       description: The subject of this event
       example:
         metadata:
-        - value: uhd-video
-          key: profile
         - value: uhd-video
           key: profile
         address: 131.37.88.10


### PR DESCRIPTION
This commit removes a duplicate metadata value example and solves #14 .

Signed-off-by: Elis Lulja <elulja@cisco.com>