### PR TITLE
Fix image name in publish docker image workflow

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -25,7 +25,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: cnwan/reader:${{ github.event.release.tag_name }}
+          tags: cnwan/cnwan-reader:${{ github.event.release.tag_name }}
       
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
As per title, the image that is being created and push docker hub is now
renamed to cnwan/cnwan-reader to keep consistency with other cnwan
projects.

Signed-off-by: Elis Lulja <elulja@cisco.com>