### PR TITLE
Add `SPDX-License-Identifier: Apache-2.0` to headers

### DIFF
--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/cmd/servicedirectory.go
+++ b/cmd/servicedirectory.go
@@ -1,5 +1,7 @@
 // Copyright © 2020, 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/main.go
+++ b/main.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/poll/cloudmap/cloudmap.go
+++ b/pkg/cmd/poll/cloudmap/cloudmap.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/poll/cloudmap/cloudmap_test.go
+++ b/pkg/cmd/poll/cloudmap/cloudmap_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/poll/cloudmap/command.go
+++ b/pkg/cmd/poll/cloudmap/command.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/poll/cloudmap/doc.go
+++ b/pkg/cmd/poll/cloudmap/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/poll/cloudmap/fake_servicediscovery.go
+++ b/pkg/cmd/poll/cloudmap/fake_servicediscovery.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/poll/cloudmap/options.go
+++ b/pkg/cmd/poll/cloudmap/options.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/poll/cloudmap/utils.go
+++ b/pkg/cmd/poll/cloudmap/utils.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/poll/cloudmap/utils_test.go
+++ b/pkg/cmd/poll/cloudmap/utils_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/poll/cloudmap/vars.go
+++ b/pkg/cmd/poll/cloudmap/vars.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/poll/command.go
+++ b/pkg/cmd/poll/command.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/poll/doc.go
+++ b/pkg/cmd/poll/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/poll/vars.go
+++ b/pkg/cmd/poll/vars.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/watch/command.go
+++ b/pkg/cmd/watch/command.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/watch/doc.go
+++ b/pkg/cmd/watch/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/watch/etcd/command.go
+++ b/pkg/cmd/watch/etcd/command.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/watch/etcd/doc.go
+++ b/pkg/cmd/watch/etcd/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/watch/etcd/fake_kv.go
+++ b/pkg/cmd/watch/etcd/fake_kv.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/watch/etcd/fake_queue.go
+++ b/pkg/cmd/watch/etcd/fake_queue.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/watch/etcd/fake_sr.go
+++ b/pkg/cmd/watch/etcd/fake_sr.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/watch/etcd/options.go
+++ b/pkg/cmd/watch/etcd/options.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/watch/etcd/utils.go
+++ b/pkg/cmd/watch/etcd/utils.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/watch/etcd/utils_test.go
+++ b/pkg/cmd/watch/etcd/utils_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/watch/etcd/vars.go
+++ b/pkg/cmd/watch/etcd/vars.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/watch/etcd/watcher.go
+++ b/pkg/cmd/watch/etcd/watcher.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/cmd/watch/etcd/watcher_test.go
+++ b/pkg/cmd/watch/etcd/watcher_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/configuration/types.go
+++ b/pkg/configuration/types.go
@@ -1,5 +1,7 @@
 // Copyright © 2021 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/internal/utils/utils.go
+++ b/pkg/internal/utils/utils.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/internal/utils/utils_test.go
+++ b/pkg/internal/utils/utils_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/openapi/api_events.go
+++ b/pkg/openapi/api_events.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/openapi/client.go
+++ b/pkg/openapi/client.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/openapi/configuration.go
+++ b/pkg/openapi/configuration.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/openapi/doc.go
+++ b/pkg/openapi/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/openapi/model_errors.go
+++ b/pkg/openapi/model_errors.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/openapi/model_event.go
+++ b/pkg/openapi/model_event.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/openapi/model_metadata.go
+++ b/pkg/openapi/model_metadata.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/openapi/model_resource_response.go
+++ b/pkg/openapi/model_resource_response.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/openapi/model_response.go
+++ b/pkg/openapi/model_response.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/openapi/model_service.go
+++ b/pkg/openapi/model_service.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/openapi/response.go
+++ b/pkg/openapi/response.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/poller/doc.go
+++ b/pkg/poller/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/poller/poller_test.go
+++ b/pkg/poller/poller_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/queue/doc.go
+++ b/pkg/queue/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/sdhandler/doc.go
+++ b/pkg/sdhandler/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/sdhandler/interface.go
+++ b/pkg/sdhandler/interface.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/sdhandler/service_directory.go
+++ b/pkg/sdhandler/service_directory.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/services/datastore.go
+++ b/pkg/services/datastore.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/services/datastore_test.go
+++ b/pkg/services/datastore_test.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/services/doc.go
+++ b/pkg/services/doc.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/services/handler.go
+++ b/pkg/services/handler.go
@@ -1,5 +1,7 @@
 // Copyright © 2020 Cisco
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
See https://github.com/CloudNativeSDWAN/cnwan-docs/discussions/4

Signed-off-by: Lori Jakab <lojakab@cisco.com>